### PR TITLE
Added method __add__ for StrSchema

### DIFF
--- a/d42/declaration/types/_str_schema.py
+++ b/d42/declaration/types/_str_schema.py
@@ -92,8 +92,8 @@ class StrSchema(Schema[StrProps]):
             raise TypeError(
                 f"Unsupported operand type for +: '{self.__class__.__name__}' and {type(other)!r}")
 
-        self_value = self.props.value or self.props.pattern
-        other_value = other.props.value or other.props.pattern
+        self_value = re.escape(self.props.value) if self.props.value else self.props.pattern
+        other_value = re.escape(other.props.value) if other.props.value else other.props.pattern
         return self.__class__(self.props.update(pattern=self_value + other_value, value=Nil))
 
     def __declare_len(self, props: StrProps, length: Any) -> StrProps:

--- a/d42/declaration/types/_str_schema.py
+++ b/d42/declaration/types/_str_schema.py
@@ -87,6 +87,15 @@ class StrSchema(Schema[StrProps]):
 
         return self.__class__(self.props.update(value=value))
 
+    def __add__(self, other: "StrSchema") -> "StrSchema":
+        if not isinstance(other, StrSchema):
+            raise TypeError(
+                f"Unsupported operand type for +: '{self.__class__.__name__}' and {type(other)!r}")
+
+        self_value = self.props.value or self.props.pattern
+        other_value = other.props.value or other.props.pattern
+        return self.__class__(self.props.update(pattern=self_value + other_value, value=Nil))
+
     def __declare_len(self, props: StrProps, length: Any) -> StrProps:
         if not isinstance(length, int):
             raise make_invalid_type_error(self, length, (int,))


### PR DESCRIPTION
### Pull Request Description

#### Added `__add__` Method to `StrSchema` Class

This Pull Request introduces the `__add__` method to the `StrSchema` class, enabling addition operations between `StrSchema` objects. With this new method:

- **Concatenation Support**: The `__add__` method allows two `StrSchema` instances to be combined by concatenating their `value` or `pattern` attributes.
- **Resulting Behavior**: The resulting `StrSchema` instance will contain a new `pattern` attribute that merges the two original strings. The `value` attribute is set to `Nil` to ensure pattern-based processing.
- **Type Safety**: If the operand is not an instance of `StrSchema`, a `TypeError` is raised.

This addition enhances the flexibility of the `StrSchema` class, providing intuitive concatenation for string schema operations.
