### PR TITLE
Improve schema mismatch error formatting with detailed subschema trace

### DIFF
--- a/d42/validation/__init__.py
+++ b/d42/validation/__init__.py
@@ -26,9 +26,10 @@ class ValidationException(AssertionError):
 
 def validate_or_fail(schema: GenericSchema, value: Any, **kwargs: Any) -> bool:
     result = validate(schema, value, **kwargs)
-    if not result.has_errors():
+    errors = [e.format(_formatter) for e in result.get_errors()]
+    if len(errors) == 0:
         return True
-    message = "\n - " + _formatter.format_validation_result(result)
+    message = "\n - " + "\n - ".join(errors)
     raise ValidationException(message)
 
 

--- a/d42/validation/__init__.py
+++ b/d42/validation/__init__.py
@@ -26,10 +26,9 @@ class ValidationException(AssertionError):
 
 def validate_or_fail(schema: GenericSchema, value: Any, **kwargs: Any) -> bool:
     result = validate(schema, value, **kwargs)
-    errors = [e.format(_formatter) for e in result.get_errors()]
-    if len(errors) == 0:
+    if not result.has_errors():
         return True
-    message = "\n - " + "\n - ".join(errors)
+    message = "\n - " + _formatter.format_validation_result(result)
     raise ValidationException(message)
 
 

--- a/d42/validation/_formatter.py
+++ b/d42/validation/_formatter.py
@@ -4,7 +4,6 @@ from typing import Any, Sequence
 from th import PathHolder
 
 from ._abstract_formatter import AbstractFormatter
-from ._validation_result import ValidationResult
 from .errors import (
     AlphabetValidationError,
     ExtraElementValidationError,
@@ -136,16 +135,8 @@ class Formatter(AbstractFormatter):
     def format_schema_missmatch_error(self, error: SchemaMismatchValidationError) -> str:
         actual_type = self._get_type(error.actual_value)
         formatted_path = self._at_path(error.path)
-
-        # Если есть только одна схема, выводим её
-        if len(error.expected_schemas) == 1:
-            return (f"Value {actual_type}{formatted_path} "
-                    f"must match {error.expected_schemas[0]!r}, but {error.actual_value!r} given")
-
-        # Если схем несколько, выводим количество и сообщение
         return (f"Value {actual_type}{formatted_path} "
-                f"must match one of {len(error.expected_schemas)} schemas, but "
-                f"{error.actual_value!r} given (best matched schema not found)")
+                f"must match any of {error.expected_schemas!r}, but {error.actual_value!r} given")
 
     def format_invalid_uuid_version_error(self, error: InvalidUUIDVersionValidationError) -> str:
         actual_type = self._get_type(error.actual_value)
@@ -153,11 +144,3 @@ class Formatter(AbstractFormatter):
         return (f"Value {actual_type}{formatted_path} "
                 f"must be a UUID version {error.expected_version!r}, "
                 f"but {error.actual_value!r} version {error.actual_version!r} given")
-
-    def format_validation_result(self, result: ValidationResult) -> str:
-        errors = result.get_errors()
-        if not errors:
-            return ""
-
-        # Форматируем все ошибки
-        return "\n - ".join(error.format(self) for error in errors)

--- a/d42/validation/_formatter.py
+++ b/d42/validation/_formatter.py
@@ -1,3 +1,4 @@
+import os
 from copy import deepcopy
 from typing import Any, Sequence
 
@@ -133,10 +134,45 @@ class Formatter(AbstractFormatter):
         return f"Value{formatted_path} contains extra key {error.extra_key!r}"
 
     def format_schema_missmatch_error(self, error: SchemaMismatchValidationError) -> str:
-        actual_type = self._get_type(error.actual_value)
-        formatted_path = self._at_path(error.path)
-        return (f"Value {actual_type}{formatted_path} "
-                f"must match any of {error.expected_schemas!r}, but {error.actual_value!r} given")
+        if error.subschema_errors is None:
+            actual_type = self._get_type(error.actual_value)
+            formatted_path = self._at_path(error.path)
+            return (f"Value {actual_type}{formatted_path} "
+                    f"must match any of {error.expected_schemas!r}, but {error.actual_value!r} "
+                    f"given")
+
+        error_lines = []
+        schema_path = getattr(error, 'schema_path', []) or []
+        level = len(schema_path)
+        prefix = "| - " * level
+        for index, errors in error.subschema_errors:
+            new_schema_path = schema_path + [index + 1]
+            schema_num = ".".join(map(str, new_schema_path))
+            schema_desc = f"{prefix}Schema {schema_num}:"
+            schema_errors = []
+            for err in errors:
+                if isinstance(err, SchemaMismatchValidationError):
+                    err.schema_path = new_schema_path
+                    nested = err.format(self).split(os.linesep)
+                    for i, line in enumerate(nested):
+                        if i == 0:
+                            schema_errors.append("| - " * (level + 1) + line)
+                        else:
+                            schema_errors.append(line)
+                else:
+                    schema_errors.append(("| - " * (level + 1)) + err.format(self))
+            if schema_errors:
+                error_lines.append(schema_desc)
+                error_lines.extend(schema_errors)
+
+        p = self._format_path(error.path)
+        msg = f"Value at {p} does not match any of the allowed schemas:"
+        lines = [msg] + error_lines
+
+        result = [lines[0]]
+        for line in lines[1:]:
+            result.append("| - " + line)
+        return os.linesep.join(result)
 
     def format_invalid_uuid_version_error(self, error: InvalidUUIDVersionValidationError) -> str:
         actual_type = self._get_type(error.actual_value)

--- a/d42/validation/_validator.py
+++ b/d42/validation/_validator.py
@@ -349,7 +349,7 @@ class Validator(SchemaVisitor[ValidationResult]):
             all_errors.append(schema_errors)
 
         result.add_error(SchemaMismatchValidationError(
-            path, value, schema.props.types, [(i, errors) for i, errors in enumerate(all_errors)]
+            path, value, schema.props.types, all_errors
         ))
         return result
 

--- a/d42/validation/_validator.py
+++ b/d42/validation/_validator.py
@@ -2,7 +2,7 @@ import re
 from copy import deepcopy
 from datetime import date, datetime
 from math import isclose
-from typing import Any, Callable, Iterator, List, Optional, Sequence, Type, Union, cast
+from typing import Any, Callable, List, Optional, Tuple, Type, cast
 from uuid import UUID
 
 from niltype import Nil, Nilable
@@ -336,52 +336,22 @@ class Validator(SchemaVisitor[ValidationResult]):
         if schema.props.types is Nil:
             return result
 
-        # Сначала проверяем, есть ли точное совпадение
-        for sch_type in schema.props.types:
+        all_errors: List[Tuple[int, List[ValidationError]]] = []
+        for index, sch_type in enumerate(schema.props.types):
             res = sch_type.__accept__(self, path=path, value=value, **kwargs)
             if not res.has_errors():
                 return result
 
-        # Проверяем все схемы и собираем ошибки
-        all_results = []
-        for sch_type in schema.props.types:
-            res = sch_type.__accept__(self, path=path, value=value, **kwargs)
-            all_results.append(res)
+            schema_errors: List[ValidationError] = []
+            for error in res.get_errors():
+                schema_errors.append(error)
 
-        # Если все схемы имеют ошибки типа, возвращаем SchemaMismatchValidationError
-        if all(isinstance(e, TypeValidationError) for res in all_results
-               for e in self._flatten_errors(res.get_errors())):
-            return result.add_error(SchemaMismatchValidationError(path, value, schema.props.types))
+            all_errors.append((index, schema_errors))
 
-        # Считаем количество конкретных ошибок для каждой схемы
-        error_counts = []
-        for res in all_results:
-            errors = self._flatten_errors(res.get_errors())
-            # Считаем только конкретные ошибки (игнорируем SchemaMismatchValidationError)
-            concrete_errors = [e for e in errors if
-                               not isinstance(e, SchemaMismatchValidationError)]
-            error_counts.append(len(concrete_errors))
-
-        # Находим минимальное количество ошибок
-        min_errors = min(error_counts)
-
-        # Если несколько схем имеют одинаковое минимальное количество ошибок,
-        # значит лучшую схему найти нельзя
-        if sum(1 for count in error_counts if count == min_errors) > 1:
-            return result.add_error(SchemaMismatchValidationError(path, value, schema.props.types))
-
-        # Находим схему с минимальным количеством ошибок
-        best_result = all_results[error_counts.index(min_errors)]
-        result.add_errors(best_result.get_errors())
+        result.add_error(SchemaMismatchValidationError(
+            path, value, schema.props.types, all_errors
+        ))
         return result
-
-    def _flatten_errors(self, errors:
-                        Sequence[Union[ValidationError, Any]]) -> Iterator[ValidationError]:
-        for error in errors:
-            if hasattr(error, 'get_errors'):
-                yield from self._flatten_errors(error.get_errors())
-            else:
-                yield error
 
     def visit_bytes(self, schema: BytesSchema, *,
                     value: Any = Nil, path: Nilable[PathHolder] = Nil,

--- a/d42/validation/_validator.py
+++ b/d42/validation/_validator.py
@@ -2,7 +2,7 @@ import re
 from copy import deepcopy
 from datetime import date, datetime
 from math import isclose
-from typing import Any, Callable, List, Optional, Tuple, Type, cast
+from typing import Any, Callable, List, Optional, Type, cast
 from uuid import UUID
 
 from niltype import Nil, Nilable
@@ -336,8 +336,8 @@ class Validator(SchemaVisitor[ValidationResult]):
         if schema.props.types is Nil:
             return result
 
-        all_errors: List[Tuple[int, List[ValidationError]]] = []
-        for index, sch_type in enumerate(schema.props.types):
+        all_errors: List[List[ValidationError]] = []
+        for sch_type in schema.props.types:
             res = sch_type.__accept__(self, path=path, value=value, **kwargs)
             if not res.has_errors():
                 return result
@@ -346,10 +346,10 @@ class Validator(SchemaVisitor[ValidationResult]):
             for error in res.get_errors():
                 schema_errors.append(error)
 
-            all_errors.append((index, schema_errors))
+            all_errors.append(schema_errors)
 
         result.add_error(SchemaMismatchValidationError(
-            path, value, schema.props.types, all_errors
+            path, value, schema.props.types, [(i, errors) for i, errors in enumerate(all_errors)]
         ))
         return result
 

--- a/d42/validation/errors/__init__.py
+++ b/d42/validation/errors/__init__.py
@@ -1,4 +1,3 @@
-import typing
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type
 
@@ -225,13 +224,11 @@ class ExtraKeyValidationError(ValidationError):
 class SchemaMismatchValidationError(ValidationError):
     def __init__(self, path: PathHolder, actual_value: Any,
                  expected_schemas: Tuple[GenericSchema, ...],
-                 subschema_errors: Optional[
-                     List[Tuple[int, List[ValidationError]]]] = None) -> None:
+                 subschema_errors: Optional[List[List[ValidationError]]] = None) -> None:
         self.path = path
         self.actual_value = actual_value
         self.expected_schemas = expected_schemas
         self.subschema_errors = subschema_errors
-        self.schema_path: Optional[typing.List[int]] = None
 
     def format(self, formatter: "Formatter") -> str:
         return formatter.format_schema_missmatch_error(self)

--- a/tests/validation/test_formatter.py
+++ b/tests/validation/test_formatter.py
@@ -304,10 +304,9 @@ def test_format_extra_key_error(path: PathHolder, formatted: str, *, formatter: 
 
 
 @pytest.mark.parametrize(("path", "formatted"), [
-    (_, "Value <class 'int'> must match one of 2 schemas, but 42 given "
-        "(best matched schema not found)"),
-    (_["id"], "Value <class 'int'> at _['id'] must match one of 2 schemas, but 42 given "
-              "(best matched schema not found)"),
+    (_, "Value <class 'int'> must match any of (schema.str, schema.none), but 42 given"),
+    (_["id"], "Value <class 'int'> at _['id'] must match any of (schema.str, schema.none), "
+              "but 42 given"),
 ])
 def test_format_schema_missmatch_error(path: PathHolder, formatted: str, *, formatter: Formatter):
     with given:

--- a/tests/validation/test_formatter.py
+++ b/tests/validation/test_formatter.py
@@ -304,9 +304,10 @@ def test_format_extra_key_error(path: PathHolder, formatted: str, *, formatter: 
 
 
 @pytest.mark.parametrize(("path", "formatted"), [
-    (_, "Value <class 'int'> must match any of (schema.str, schema.none), but 42 given"),
-    (_["id"], "Value <class 'int'> at _['id'] must match any of (schema.str, schema.none), "
-              "but 42 given"),
+    (_, "Value <class 'int'> must match one of 2 schemas, but 42 given "
+        "(best matched schema not found)"),
+    (_["id"], "Value <class 'int'> at _['id'] must match one of 2 schemas, but 42 given "
+              "(best matched schema not found)"),
 ])
 def test_format_schema_missmatch_error(path: PathHolder, formatted: str, *, formatter: Formatter):
     with given:

--- a/tests/validation/test_formatter.py
+++ b/tests/validation/test_formatter.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 
 import pytest
@@ -358,15 +359,15 @@ def test_format_any_schema_missmatch_error(*, formatter: Formatter):
         res = error.format(formatter)
 
     with then:
-        expected = (
-            "Value at _ does not match any of the allowed schemas:\n"
-            "| - Schema 1:\n"
-            "| - | - Value 3.14 must be <class 'NoneType'>, but <class 'float'> given\n"
-            "| - Schema 2:\n"
-            "| - | - Value 3.14 must be <class 'str'>, but <class 'float'> given\n"
-            "| - Schema 3:\n"
+        expected = os.linesep.join([
+            "Value at _ does not match any of the allowed schemas:",
+            "| - Schema 1:",
+            "| - | - Value 3.14 must be <class 'NoneType'>, but <class 'float'> given",
+            "| - Schema 2:",
+            "| - | - Value 3.14 must be <class 'str'>, but <class 'float'> given",
+            "| - Schema 3:",
             "| - | - Value 3.14 must be <class 'int'>, but <class 'float'> given"
-        )
+        ])
         assert res == expected
 
 
@@ -396,15 +397,15 @@ def test_format_any_schema_with_nested_schemas_missmatch_error(*, formatter: For
         res = error.format(formatter)
 
     with then:
-        expected = (
-            "Value at _ does not match any of the allowed schemas:\n"
-            "| - Schema 1:\n"
-            "| - | - Value 3.14 must be <class 'NoneType'>, but <class 'float'> given\n"
-            "| - Schema 2:\n"
-            "| - | - Value at _ does not match any of the allowed schemas:\n"
-            "| - | - | - Schema 2.1:\n"
-            "| - | - | - | - Value 3.14 must be <class 'str'>, but <class 'float'> given\n"
-            "| - | - | - Schema 2.2:\n"
+        expected = os.linesep.join([
+            "Value at _ does not match any of the allowed schemas:",
+            "| - Schema 1:",
+            "| - | - Value 3.14 must be <class 'NoneType'>, but <class 'float'> given",
+            "| - Schema 2:",
+            "| - | - Value at _ does not match any of the allowed schemas:",
+            "| - | - | - Schema 2.1:",
+            "| - | - | - | - Value 3.14 must be <class 'str'>, but <class 'float'> given",
+            "| - | - | - Schema 2.2:",
             "| - | - | - | - Value 3.14 must be <class 'int'>, but <class 'float'> given"
-        )
+        ])
         assert res == expected

--- a/tests/validation/test_formatter.py
+++ b/tests/validation/test_formatter.py
@@ -360,12 +360,12 @@ def test_format_any_schema_missmatch_error(*, formatter: Formatter):
     with then:
         expected = (
             "Value at _ does not match any of the allowed schemas:\n"
-            " | Schema 1:\n"
-            " |   - Value 3.14 must be <class 'NoneType'>, but <class 'float'> given\n"
-            " | Schema 2:\n"
-            " |   - Value 3.14 must be <class 'str'>, but <class 'float'> given\n"
-            " | Schema 3:\n"
-            " |   - Value 3.14 must be <class 'int'>, but <class 'float'> given"
+            "| - Schema 1:\n"
+            "| - | - Value 3.14 must be <class 'NoneType'>, but <class 'float'> given\n"
+            "| - Schema 2:\n"
+            "| - | - Value 3.14 must be <class 'str'>, but <class 'float'> given\n"
+            "| - Schema 3:\n"
+            "| - | - Value 3.14 must be <class 'int'>, but <class 'float'> given"
         )
         assert res == expected
 
@@ -398,13 +398,13 @@ def test_format_any_schema_with_nested_schemas_missmatch_error(*, formatter: For
     with then:
         expected = (
             "Value at _ does not match any of the allowed schemas:\n"
-            " | Schema 1:\n"
-            " |   - Value 3.14 must be <class 'NoneType'>, but <class 'float'> given\n"
-            " | Schema 2:\n"
-            " |   - Value at _ does not match any of the allowed schemas:\n"
-            " |   -  |    | Schema 2.1:\n"
-            " |   -  |    |   - Value 3.14 must be <class 'str'>, but <class 'float'> given\n"
-            " |   -  |    | Schema 2.2:\n"
-            " |   -  |    |   - Value 3.14 must be <class 'int'>, but <class 'float'> given"
+            "| - Schema 1:\n"
+            "| - | - Value 3.14 must be <class 'NoneType'>, but <class 'float'> given\n"
+            "| - Schema 2:\n"
+            "| - | - Value at _ does not match any of the allowed schemas:\n"
+            "| - | - | - Schema 2.1:\n"
+            "| - | - | - | - Value 3.14 must be <class 'str'>, but <class 'float'> given\n"
+            "| - | - | - Schema 2.2:\n"
+            "| - | - | - | - Value 3.14 must be <class 'int'>, but <class 'float'> given"
         )
         assert res == expected

--- a/tests/validation/test_formatter.py
+++ b/tests/validation/test_formatter.py
@@ -349,9 +349,9 @@ def test_format_any_schema_missmatch_error(*, formatter: Formatter):
             value,
             (schema.none, schema.str, schema.int),
             [
-                (0, [TypeValidationError(PathHolder(), value, type(None))]),
-                (1, [TypeValidationError(PathHolder(), value, str)]),
-                (2, [TypeValidationError(PathHolder(), value, int)])
+                [TypeValidationError(PathHolder(), value, type(None))],
+                [TypeValidationError(PathHolder(), value, str)],
+                [TypeValidationError(PathHolder(), value, int)]
             ]
         )
 
@@ -379,8 +379,8 @@ def test_format_any_schema_with_nested_schemas_missmatch_error(*, formatter: For
             value,
             (schema.str, schema.int),
             [
-                (0, [TypeValidationError(PathHolder(), value, str)]),
-                (1, [TypeValidationError(PathHolder(), value, int)])
+                [TypeValidationError(PathHolder(), value, str)],
+                [TypeValidationError(PathHolder(), value, int)]
             ]
         )
         error = SchemaMismatchValidationError(
@@ -388,8 +388,8 @@ def test_format_any_schema_with_nested_schemas_missmatch_error(*, formatter: For
             value,
             (schema.none, schema.dict({"type": schema.str})),
             [
-                (0, [TypeValidationError(PathHolder(), value, type(None))]),
-                (1, [nested_error])
+                [TypeValidationError(PathHolder(), value, type(None))],
+                [nested_error]
             ]
         )
 

--- a/tests/validation/test_validation_errors.py
+++ b/tests/validation/test_validation_errors.py
@@ -146,13 +146,13 @@ def test_validation_schema_mismatch_error():
             PathHolder(),
             "key",
             (IntSchema(),),
-            [(0, [TypeValidationError(PathHolder(), "key", int)])]
+            [[TypeValidationError(PathHolder(), "key", int)]]
         )
 
     with then:
         assert repr(res) == (
             "SchemaMismatchValidationError(PathHolder(), 'key', (schema.int,), "
-            "[(0, [TypeValidationError(PathHolder(), 'key', <class 'int'>)])])"
+            "[[TypeValidationError(PathHolder(), 'key', <class 'int'>)]])"
         )
 
 

--- a/tests/validation/test_validation_errors.py
+++ b/tests/validation/test_validation_errors.py
@@ -142,10 +142,18 @@ def test_validation_extra_key_error():
 
 def test_validation_schema_mismatch_error():
     with when:
-        res = SchemaMismatchValidationError(PathHolder(), "key", (IntSchema(),))
+        res = SchemaMismatchValidationError(
+            PathHolder(),
+            "key",
+            (IntSchema(),),
+            [(0, [TypeValidationError(PathHolder(), "key", int)])]
+        )
 
     with then:
-        assert repr(res) == "SchemaMismatchValidationError(PathHolder(), 'key', (schema.int,))"
+        assert repr(res) == (
+            "SchemaMismatchValidationError(PathHolder(), 'key', (schema.int,), "
+            "[(0, [TypeValidationError(PathHolder(), 'key', <class 'int'>)])])"
+        )
 
 
 def test_validation_invalid_uuid_version_error():

--- a/tests/validation/types/any/test_any_validation.py
+++ b/tests/validation/types/any/test_any_validation.py
@@ -49,7 +49,7 @@ def test_any_type_validation_error():
                 PathHolder(),
                 value,
                 types,
-                [(0, [TypeValidationError(PathHolder(), value, type(None))])]
+                [[TypeValidationError(PathHolder(), value, type(None))]]
             )
         ]
 
@@ -70,7 +70,7 @@ def test_any_types_validation_error():
         p = PathHolder()
         e1 = TypeValidationError(p, value, int)
         e2 = TypeValidationError(p, value, str)
-        errs = [(0, [e1]), (1, [e2])]
+        errs = [[e1], [e2]]
 
     with when:
         result = validate(schema.any(*types), value)
@@ -91,8 +91,8 @@ def test_any_type_validation_kwargs():
     with then:
         assert result.get_errors() == [
             SchemaMismatchValidationError(path, actual_value, (schema.none,),
-                                          [(0, [TypeValidationError(path,
-                                                                    actual_value, type(None))])])
+                                          [[TypeValidationError(path,
+                                                                actual_value, type(None))]])
         ]
 
 
@@ -110,9 +110,9 @@ def test_nested_any_validation_error():
                 value,
                 (schema.none, schema.str, schema.int),
                 [
-                    (0, [TypeValidationError(PathHolder(), value, type(None))]),
-                    (1, [TypeValidationError(PathHolder(), value, str)]),
-                    (2, [TypeValidationError(PathHolder(), value, int)])
+                    [TypeValidationError(PathHolder(), value, type(None))],
+                    [TypeValidationError(PathHolder(), value, str)],
+                    [TypeValidationError(PathHolder(), value, int)]
                 ]
             )
         ]

--- a/tests/validation/types/any/test_any_validation.py
+++ b/tests/validation/types/any/test_any_validation.py
@@ -98,12 +98,10 @@ def test_any_type_validation_kwargs():
 
 def test_nested_any_validation_error():
     with given:
-        value = 3.14  # float value that doesn't match any of the schemas
-        nested_any = schema.any(schema.str, schema.int)
-        outer_any = schema.any(schema.none, nested_any)
+        value = 3.14
 
     with when:
-        result = validate(outer_any, value)
+        result = validate(schema.any(schema.none, schema.any(schema.str, schema.int)), value)
 
     with then:
         assert result.get_errors() == [

--- a/tests/validation/types/any/test_any_validation.py
+++ b/tests/validation/types/any/test_any_validation.py
@@ -6,7 +6,11 @@ from th import PathHolder
 
 from d42 import schema
 from d42.validation import validate
-from d42.validation.errors import SchemaMismatchValidationError
+from d42.validation.errors import (
+    ExtraKeyValidationError,
+    MissingKeyValidationError,
+    SchemaMismatchValidationError,
+)
 
 
 @pytest.mark.parametrize("value", [
@@ -83,4 +87,104 @@ def test_any_type_validation_kwargs():
     with then:
         assert result.get_errors() == [
             SchemaMismatchValidationError(path, actual_value, (schema.none,))
+        ]
+
+
+def test_any_all_schemas_have_type_errors():
+    with given:
+        value = 42
+        types = (schema.str, schema.none)
+
+    with when:
+        result = validate(schema.any(*types), value)
+
+    with then:
+        assert result.get_errors() == [
+            SchemaMismatchValidationError(PathHolder(), value, types)
+        ]
+
+
+def test_any_one_schema_has_min_errors():
+    with given:
+        value = {"id": "42", "type": "banana"}
+        BananaSchema = schema.dict({
+            "id": schema.str,
+            "type": schema.str("banana"),
+        })
+        AppleSchema = schema.dict({
+            "id": schema.str,
+            "type": schema.str("apple"),
+        })
+
+    with when:
+        result = validate(schema.any(BananaSchema, AppleSchema), value)
+
+    with then:
+        assert not result.has_errors()
+
+
+def test_any_multiple_schemas_have_min_errors():
+    with given:
+        value = {"id": "42", "type": "banana"}
+        BananaSchema1 = schema.dict({
+            "id": schema.str,
+            "type": schema.str("banana"),
+        })
+        BananaSchema2 = schema.dict({
+            "id": schema.str,
+            "type": schema.str("banana"),
+        })
+        AppleSchema = schema.dict({
+            "id": schema.str,
+            "type": schema.str("apple"),
+        })
+
+    with when:
+        result = validate(schema.any(BananaSchema1, BananaSchema2, AppleSchema), value)
+
+    with then:
+        assert not result.has_errors()
+
+
+def test_any_schema_with_extra_fields():
+    with given:
+        value = {"id": "42", "type": "banana", "extra": "field"}
+        BananaSchema = schema.dict({
+            "id": schema.str,
+            "type": schema.str("banana"),
+        })
+        AppleSchema = schema.dict({
+            "id": schema.str,
+            "type": schema.str("apple"),
+        })
+
+    with when:
+        result = validate(schema.any(BananaSchema, AppleSchema), value)
+
+    with then:
+        assert result.get_errors() == [
+            ExtraKeyValidationError(PathHolder(), value, "extra")
+        ]
+
+
+def test_any_schema_with_missing_fields():
+    with given:
+        value = {"id": "42", "type": "banana"}
+        BananaSchema = schema.dict({
+            "id": schema.str,
+            "type": schema.str("banana"),
+            "name": schema.str,
+        })
+        AppleSchema = schema.dict({
+            "id": schema.str,
+            "type": schema.str("apple"),
+            "name": schema.str,
+        })
+
+    with when:
+        result = validate(schema.any(BananaSchema, AppleSchema), value)
+
+    with then:
+        assert result.get_errors() == [
+            MissingKeyValidationError(PathHolder(), value, "name")
         ]


### PR DESCRIPTION
This PR improves `SchemaMismatchValidationError` handling by adding support for nested subschema error reporting and enhancing the error message formatting. It introduces a recursive formatter for clearer, indented output and updates the validator to collect detailed errors from each schema variant.